### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "mongoose": "^5.2.7",
     "node-sass": "^4.9.3",
     "nodemon": "^1.17.2",
-    "npm": "^6.3.0",
     "postcss-loader": "^2.1.3",
     "react": "^16.4.2",
     "react-anime": "^2.1.0",


### PR DESCRIPTION

Hello mariusgrafu!

It seems like you have npm as one of your (dev-) dependency in puffysticksReact.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
